### PR TITLE
Feature compact

### DIFF
--- a/derivative.sty
+++ b/derivative.sty
@@ -12,15 +12,18 @@
 % This work has the LPPL maintenance status `maintained'.
 % 
 % The Current Maintainer of this work is Simon Jensen.
+% Contributors: Romain Noel
 
 \NeedsTeXFormat{LaTeX2e}
 
-\RequirePackage{expl3,xparse}[2021/11/07]
+\RequirePackage{expl3}[2021/11/07]
+\RequirePackage{xparse}[2021/11/07]
 \RequirePackage{l3keys2e}
 \ProvidesExplPackage{derivative}{2022/07/09}{1.2}{Nice and easy derivatives and differentials for LaTeX}
 
 \bool_new:N \l__deriv_pkg_italic_bool
 \bool_new:N \l__deriv_pkg_upright_bool
+
 
 \keys_define:nn { deriv/pkg }
 {
@@ -551,7 +554,7 @@
 % variant, function, variable, sb-point, sp-point
 \cs_new_protected:Npn \__deriv_dv_both:nnnnn #1 #2 #3 #4 #5
 {
-	\__deriv_dv_preparation:Nnn \l__deriv_dv_denom_tl {#1} {#3}
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star}
 	\__deriv_evaluation_slash:nnnn {#1} {#4} {#5}
 	{
 		\__deriv_fraction_slash:nn {#1}
@@ -566,7 +569,7 @@
 % variant, function, variable, sb-point, sp-point
 \cs_new_protected:Npn \__deriv_dv_star:nnnnn #1 #2 #3 #4 #5
 {
-	\__deriv_dv_preparation:Nnn \l__deriv_dv_denom_tl {#1} {#3}
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star}
 	\__deriv_evaluation:nnnn {#1} {#4} {#5}
 	{
 		\__deriv_fraction:nn {#1}
@@ -581,7 +584,7 @@
 % variant, function, variable, sb-point, sp-point
 \cs_new_protected:Npn \__deriv_dv_slash:nnnnn #1 #2 #3 #4 #5
 {
-	\__deriv_dv_preparation:Nnn \l__deriv_dv_denom_tl {#1} {#3}
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {}
 	\__deriv_evaluation_slash:nnnn {#1} {#4} {#5}
 	{
 		\__deriv_fraction_slash:nn {#1}
@@ -595,7 +598,7 @@
 % variant, function, variable, sb-point, sp-point
 \cs_new_protected:Npn \__deriv_dv_none:nnnnn #1 #2 #3 #4 #5
 {
-	\__deriv_dv_preparation:Nnn \l__deriv_dv_denom_tl {#1} {#3}
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {}
 	\__deriv_evaluation:nnnn {#1} {#4} {#5}
 	{
 		\__deriv_fraction:nn {#1}
@@ -627,17 +630,17 @@
 % dv
 \cs_new_protected:Npn \__deriv_dv_denominator:n #1
 { \tl_use:N \l__deriv_dv_denom_tl }
-% denom-tl, variant, variable
-\cs_new_protected:Npn \__deriv_dv_preparation:Nnn #1 #2 #3
+% denom-tl, variant, variable, if star
+\cs_new_protected:Npn \__deriv_dv_preparation:Nnnn #1 #2 #3 #4
 {
 	\tl_clear:N #1
 	\seq_set_from_clist:Nn \l__deriv_dv_var_seq {#3}
 	\seq_set_from_clist:Nc \l__deriv_dv_order_seq { l__deriv_#2_misc_order_clist }
 	
-	\tl_use:c { l__deriv_#2_style_var_tl } \l__deriv_dv_var_seq \l__deriv_dv_order_seq #1 {#2}
+	\tl_use:c { l__deriv_#2_style_var#4_tl } \l__deriv_dv_var_seq \l__deriv_dv_order_seq #1 {#2} {#4}
 }
-% var_seq, order_seq, denom-tl, variant
-\cs_new_protected:Npn \__deriv_dv_build_multiple:NNNn #1 #2 #3 #4
+% var_seq, order_seq, denom-tl, variant, if star
+\cs_new_protected:Npn \__deriv_dv_build_multiple:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
 	\__deriv_adjust_ord_seq:NN \l__deriv_var_count_int #2
@@ -655,7 +658,7 @@
 		{
 			\__deriv_insert_inf:n {#4}
 			\__deriv_insert_mskip:nn {#4} { inf_var }
-			\__deriv_insert_var:Nnn \l__deriv_tmpb_tl {##2} {#4}
+			\__deriv_insert_var:Nnnn \l__deriv_tmpb_tl {##2} {#4} {#5}
 			\__deriv_show_order:NTF \l__deriv_tmpa_tl
 			{
 				\__deriv_insert_ord:Nnn \l__deriv_tmpa_tl {#4} { var_ord }
@@ -670,25 +673,39 @@
 	}
 }
 % var_seq, order_seq, denom-tl, variant
-\cs_new_protected:Npn \__deriv_dv_build_single:NNNn #1 #2 #3 #4
+\cs_new_protected:Npn \__deriv_dv_build_single:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
-	\tl_set:Nf \l__deriv_tmpa_tl { \seq_use:Nn #1 { \__deriv_insert_mskip:nn {#4} { var_var } } }
+	\__deriv_adjust_ord_seq:NN \l__deriv_var_count_int #2
+	
+	\str_if_eq:cNT { l__deriv_#4_misc_mixed_order_tl } 1 
+	{ \__deriv_mixed_order:cNn { l__deriv_#4_misc_mixed_order_tl } #2 {#4} }
 	
 	\__deriv_var_bool_seq:cNN { l__deriv_#4_misc_var_clist } \l__deriv_tmpa_seq \l__deriv_var_count_int
 	
-	\seq_pop_left:NN #2 \l__deriv_tmpb_tl
-	\seq_pop_left:NN \l__deriv_tmpa_seq \l__deriv_tmpc_tl
 	\tl_put_right:Nx #3
 	{
 		\__deriv_insert_inf:n {#4}
 		\__deriv_insert_mskip:nn {#4} { inf_var }
-		\__deriv_insert_var:NVn \l__deriv_tmpc_tl \l__deriv_tmpa_tl {#4}
-		\__deriv_show_order:NT \l__deriv_tmpb_tl
-		{ \__deriv_insert_ord:Nnn \l__deriv_tmpb_tl {#4} { var_ord } }
 	}
-	\str_if_eq:cNT { l__deriv_#4_misc_mixed_order_tl } 1
-	{ \tl_set_eq:cN { l__deriv_#4_misc_mixed_order_tl } \l__deriv_tmpb_tl }
+	\seq_map_indexed_inline:Nn #1
+	{
+		\seq_pop_left:NN #2 \l__deriv_tmpa_tl
+		\seq_pop_left:NN \l__deriv_tmpa_seq \l__deriv_tmpb_tl
+		\tl_put_right:Nx #3
+		{
+			\__deriv_insert_var:Nnnn \l__deriv_tmpb_tl {##2} {#4} {#5}
+			\__deriv_show_order:NTF \l__deriv_tmpa_tl
+			{
+				\__deriv_insert_ord:Nnn \l__deriv_tmpa_tl {#4} { var_ord }
+				\int_compare:nNnF {##1} = { \l__deriv_var_count_int }
+				{ \__deriv_insert_mskip:nn {#4} { ord_var } }
+			}
+			{}
+			\int_compare:nNnF {##1} = { \l__deriv_var_count_int }
+			{ \__deriv_insert_mskip:nn {#4} { var_var } }
+		}
+	}
 }
 % var_seq, order_seq
 \cs_new_protected:Npn \__deriv_adjust_ord_seq:NN #1 #2
@@ -819,7 +836,7 @@
 		}
 	}
 }
-% var-seq, order-seq,  print-tl, variant
+% var-seq, order-seq,  print-tl, variant, if star
 \cs_new_protected:Npn \__deriv_i_build_multiple:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
@@ -846,7 +863,7 @@
 		}
 	}
 }
-% var-seq, order-seq,  print-tl, variant
+% var-seq, order-seq,  print-tl, variant, if star
 \cs_new_protected:Npn \__deriv_i_build_mixed:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }

--- a/derivative.sty
+++ b/derivative.sty
@@ -191,8 +191,8 @@
 \prop_const_from_keyval:Nn \c__deriv_i_pkg_keys_prop
 {
 	style-inf = d,
-	style-notation = multiple,
-	style-notation-* = single,
+	style-var = {multiple-left},
+	style-var-* = {single-low},
 	scale-var    = auto,
 	scale-var-*  = auto,
 	delims-var   = (),
@@ -201,6 +201,8 @@
 	sep-inf-ord  = 0,
 	sep-inf-var  = 0,
 	sep-ord-var  = 0,
+	sep-var-ord  = 0,
+	sep-ord-inf  = \mathop{}\!,
 	sep-var-inf  = \mathop{}\!,
 	sep-var-var  = {,},
 	sep-ord-ord  = {,},
@@ -238,8 +240,8 @@
 	\keys_define:nn { deriv/dv/#1 }
 	{
 		style-inf    .tl_set:c  = { l__deriv_dv_#1_style_inf_tl },
-		style-var    .code:n    = { \__deriv_set_style_var:nnn {#1} {##1} {} },
-		style-var-*  .code:n    = { \__deriv_set_style_var:nnn {#1} {##1} {_star} },
+		style-var    .code:n    = { \__deriv_dv_set_style_var:nnn {#1} {##1} {} },
+		style-var-*  .code:n    = { \__deriv_dv_set_style_var:nnn {#1} {##1} {_star} },
 		style-frac   .cs_set:cp = { __deriv_dv_#1_style_frac:nn } {##1},
 		style-frac-/ .cs_set:cp = { __deriv_dv_#1_style_frac_slash:nn } {##1},
 		
@@ -315,7 +317,7 @@
 	}
 }
 % variant, value, name
-\cs_new:Npn \__deriv_set_style_var:nnn #1 #2 #3
+\cs_new:Npn \__deriv_dv_set_style_var:nnn #1 #2 #3
 {
 	\str_case:nnF {#2}
 	{
@@ -330,14 +332,21 @@
 		{#2} {'#2'}
 	}
 }
-% varaint, value, name
-\cs_new:Npn \__deriv_set_style_notation:nnn #1 #2 #3
+% % varaint, value, name
+% variant, value, name
+\cs_new:Npn \__deriv_i_set_style_var:nnn #1 #2 #3
 {
-	\str_case:nn {#2}
+	\str_case:nnF {#2}
 	{
-		{ single   } { \tl_set:cn { l__deriv_i_#1_style_notation#3_tl } { \__deriv_i_build_single:NNNnn   } }
-		{ multiple } { \tl_set:cn { l__deriv_i_#1_style_notation#3_tl } { \__deriv_i_build_multiple:NNNnn } }
-		{ mixed    } { \tl_set:cn { l__deriv_i_#1_style_notation#3_tl } { \__deriv_i_build_mixed:NNNnn    } }
+		{ single-up      } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_dv_build_single:NNNnn   } }
+		{ single-low     } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_i_build_single:NNNnn   } }
+		{ multiple-right } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_dv_build_multiple:NNNnn } }
+		{ multiple-left  } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_i_build_multiple:NNNnn } }
+		{ mixed          } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_i_build_mixed:NNNnn    } }
+	}
+	{ 
+		\msg_error:nnxx { deriv } { differential-option-not-defined } 
+		{#2} {'#2'}
 	}
 }
 % dv_variant, scale, name
@@ -377,8 +386,8 @@
 	\keys_define:nn { deriv/i/#1 }
 	{
 		style-inf .tl_set:c = { l__deriv_i_#1_style_inf_tl },
-		style-notation   .code:n   = { \__deriv_set_style_notation:nnn {#1} {##1} {}  },
-		style-notation-* .code:n   = { \__deriv_set_style_notation:nnn {#1} {##1} { _star } },
+		style-var   .code:n   = { \__deriv_i_set_style_var:nnn {#1} {##1} {}  },
+		style-var-* .code:n   = { \__deriv_i_set_style_var:nnn {#1} {##1} { _star } },
 		
 		scale-var   .choices:nn = { auto, none, big, Big, bigg, Bigg } { \__deriv_set_scale:nnn {i_#1} {##1} { var } },
 		scale-var-* .choices:nn = { auto, none, big, Big, bigg, Bigg } { \__deriv_set_scale:nnn {i_#1} {##1} { var_slash } },
@@ -389,7 +398,9 @@
 		sep-begin   .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_begin_tl   } {##1} },
 		sep-inf-ord .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_inf_ord_tl } {##1} },
 		sep-inf-var .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_inf_var_tl } {##1} },
+		sep-ord-inf .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_ord_inf_tl } {##1} },
 		sep-ord-var .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_ord_var_tl } {##1} },
+		sep-var-ord .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_var_ord_tl } {##1} },
 		sep-var-inf .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_var_inf_tl } {##1} },
 		sep-var-var .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_var_var_tl } {##1} },
 		sep-ord-ord .code:n = { \__deriv_set_rubber_length:cn { l__deriv_i_#1_sep_ord_ord_tl } {##1} },
@@ -503,10 +514,10 @@
 % variant
 \cs_new_protected:Npn \__deriv_i_variables:n #1
 {
-	\__deriv_new:nnnn { tl    } {i_#1} { style  } { inf, notation, notation_star }
+	\__deriv_new:nnnn { tl    } {i_#1} { style  } { inf, var, var_star }
 	\__deriv_new:nnnn { tl    } {i_#1} { scale  } { var, var_star }
 	\__deriv_new:nnnn { tl    } {i_#1} { delims } { var, var_star }
-	\__deriv_new:nnnn { tl    } {i_#1} { sep    } { begin, inf_ord, inf_var, ord_var, var_inf, var_var, ord_ord, end }
+	\__deriv_new:nnnn { tl    } {i_#1} { sep    } { begin, inf_ord, inf_var, ord_inf, ord_var, var_inf, var_var, ord_ord, end }
 	\__deriv_new:nnnn { bool  } {i_#1} { switch } { star }
 	\__deriv_new:nnnn { bool  } {i_#1} { mics   } { fun, var, frac }
 	\__deriv_new:nnnn { clist } {i_#1} { misc   } { order }
@@ -532,12 +543,12 @@
 % new/delare/renew/provide, variant, macro
 \cs_new_protected:Npn \deriv_dv_define:Nnn #1 #2 #3
 {
-	\exp_args:Nne #1 {#3}{ s o m t/ m !e{\char_generate:nn {`_}{8}^} }
+	\exp_args:Nne #1 {#3}{ s o m t/ t! m !e{\char_generate:nn {`_}{8}^} }
 	{
 	\group_begin:
 		\deriv_local_keys:nnn {##2} { dv } {#2}
 		
-		\exp_args:Nc \bool_if:nTF {l__deriv_dv_#2_switch_compact_bool}
+		\exp_args:Nnc \bool_xor:nnTF {##5} {l__deriv_dv_#2_switch_compact_bool}
 		{%compact = true
 			\exp_args:Nnc \bool_xor:nnTF {##4} { l__deriv_dv_#2_switch_slash_bool }
 			{% slash = true
@@ -545,21 +556,21 @@
 				{% star and slash + compact
 					\msg_error:nnxx { deriv } { differential-options-incompatible } 
 					{'slash','star'~and~'compact'} {'slash','star'~and~'compact'}
-					\__deriv_dv_both:nnnnn  {dv_#2} {##3} {##5} {##6} {##7} 
+					\__deriv_dv_both:nnnnn  {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 				{% slash only + compact
 					\msg_error:nnxx { deriv } { differential-options-incompatible } 
 					{'slash'~and~'compat'} {'slash'~and~'compact'}
-					\__deriv_dv_slash:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+					\__deriv_dv_slash:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 			}
 			{% slash = false
 				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
 				{% star only + compact
-					\__deriv_dv_compact_star:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+					\__deriv_dv_compact_star:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 				{% no star no slash + compact
-					\__deriv_dv_compact:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+					\__deriv_dv_compact:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 			}
 		}
@@ -568,19 +579,19 @@
 			{% slash = true
 				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
 				{% star and slash 
-					\__deriv_dv_both:nnnnn  {dv_#2} {##3} {##5} {##6} {##7} 
+					\__deriv_dv_both:nnnnn  {dv_#2} {##3} {##6} {##7} {##8}  
 				}
 				{% slash only
-					\__deriv_dv_slash:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+					\__deriv_dv_slash:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 			}
 			{% slash = false
 				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
 				{% star only  
-					\__deriv_dv_star:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+					\__deriv_dv_star:nnnnn {dv_#2} {##3} {##6} {##7} {##8}  
 				}
 				{% no star no slash
-					\__deriv_dv_none:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+					\__deriv_dv_none:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 			}
 		}
@@ -867,7 +878,7 @@
 	\seq_set_from_clist:Nn \l__deriv_i_var_seq {#3}
 	\seq_set_from_clist:Nc \l__deriv_i_order_seq { l__deriv_#2_misc_order_clist }
 	
-	\tl_use:c { l__deriv_#2_style_notation#4_tl } \l__deriv_i_var_seq \l__deriv_i_order_seq #1 {#2} {#4}
+	\tl_use:c { l__deriv_#2_style_var#4_tl } \l__deriv_i_var_seq \l__deriv_i_order_seq #1 {#2} {#4}
 }
 % var-seq, order-seq,  print-tl, variant, if star
 \cs_new_protected:Npn \__deriv_i_build_single:NNNnn #1 #2 #3 #4 #5
@@ -1534,13 +1545,13 @@
 	\DeclareDerivative{\odv}{\mathnormal{d}}
 	\DeclareDerivative{\mdv}{\mathnormal{D}}
 	\DeclareDifferential{\odif}{\mathnormal{d}}
-	\DeclareDifferential{\mdif}{\mathnormal{D}}[style-notation=single, style-notation-*=mixed]
+	\DeclareDifferential{\mdif}{\mathnormal{D}}[style-var=single-low, style-var-*=mixed]
 }
 {
 	\DeclareDerivative{\odv}{\mathrm{d}}
 	\DeclareDerivative{\mdv}{\mathrm{D}}
 	\DeclareDifferential{\odif}{\mathrm{d}}
-	\DeclareDifferential{\mdif}{\mathrm{D}}[style-notation=single, style-notation-*=mixed]
+	\DeclareDifferential{\mdif}{\mathrm{D}}[style-var=single-low, style-var-*=mixed]
 }
 
 \DeclareDerivative{\fdv}{\delta}
@@ -1550,7 +1561,7 @@
 
 \DeclareDifferential{\fdif}{\delta}
 \DeclareDifferential{\adif}{\Delta}
-\DeclareDifferential{\pdif}{\partial}[style-notation=single, style-notation-*=mixed]
+\DeclareDifferential{\pdif}{\partial}[style-var=single-low, style-var-*=mixed]
 
 \endinput
 

--- a/derivative.sty
+++ b/derivative.sty
@@ -136,15 +136,27 @@
 \regex_const:Nn \c__deriv_cs_numbers_regex { \A\-?\d+(?:,\d+){0,2}\Z }
 \tl_const:Nn \c__deriv_digits_tl {-1234567890}
 
-%%%%%  default values  %%%%%
 
+% numerator, denumerator
+\DeclareDocumentCommand{\compactfrac}{ m m }
+{ #1 #2 }
+
+%%%%%  default values  %%%%%
 \prop_const_from_keyval:Nn \c__deriv_dv_pkg_keys_prop
 {
 	style-inf     = d,
 	style-frac    = \frac,
 	style-frac-/  = \slashfrac,
-	style-var     = {single-up},
+	style-frac-/! = \slashfrac,
+	style-frac-!  = \compactfrac,
+	style-var     = {single-right},
 	style-var-*   = {multiple-right},
+	style-var-/   = {single-mixed},
+	style-var-!   = {multiple-mixed},
+	style-var-/!  = {single-single},
+	style-var-*/! = {multiple-left},
+	style-var-*/  = {single-right},
+	style-var-*!  = {multiple-right},
 	scale-eval    = auto,
 	scale-eval-/  = auto,
 	scale-fun     = auto,
@@ -172,8 +184,8 @@
 	sep-eval-sp   = 0,
 	switch-*      = false,
 	switch-/      = false,
+	switch-!      = false,
 	switch-sort   = true,
-	switch-compact= false,
 	sort-method         = {sign, symbol, abs},
 	sort-numerical      = auto,
 	sort-abs-reverse    = false,
@@ -192,7 +204,7 @@
 {
 	style-inf = d,
 	style-var = {multiple-left},
-	style-var-* = {single-low},
+	style-var-* = {single-mixed},
 	scale-var    = auto,
 	scale-var-*  = auto,
 	delims-var   = (),
@@ -240,10 +252,18 @@
 	\keys_define:nn { deriv/dv/#1 }
 	{
 		style-inf    .tl_set:c  = { l__deriv_dv_#1_style_inf_tl },
-		style-var    .code:n    = { \__deriv_dv_set_style_var:nnn {#1} {##1} {} },
-		style-var-*  .code:n    = { \__deriv_dv_set_style_var:nnn {#1} {##1} {_star} },
+		style-var    .code:n    = { \__deriv_set_style_var:nnn {dv_#1} {##1} {} },
+		style-var-*  .code:n    = { \__deriv_set_style_var:nnn {dv_#1} {##1} {_star} },
+		style-var-/  .code:n    = { \__deriv_set_style_var:nnn {dv_#1} {##1} {_slash} },
+		style-var-!  .code:n    = { \__deriv_set_style_var:nnn {dv_#1} {##1} {_compact} },
+		style-var-*/  .code:n    = { \__deriv_set_style_var:nnn {dv_#1} {##1} {_star_slash} },
+		style-var-*!  .code:n    = { \__deriv_set_style_var:nnn {dv_#1} {##1} {_star_compact} },
+		style-var-/!  .code:n    = { \__deriv_set_style_var:nnn {dv_#1} {##1} {_slash_compact} },
+		style-var-*/!  .code:n    = { \__deriv_set_style_var:nnn {dv_#1} {##1} {_star_slash_compact} },
 		style-frac   .cs_set:cp = { __deriv_dv_#1_style_frac:nn } {##1},
 		style-frac-/ .cs_set:cp = { __deriv_dv_#1_style_frac_slash:nn } {##1},
+		style-frac-! .cs_set:cp = { __deriv_dv_#1_style_frac_compact:nn } {##1},
+		style-frac-/! .cs_set:cp = { __deriv_dv_#1_style_frac_slash_compact:nn } {##1},
 		
 		scale-eval   .choices:nn = { auto, none, big, Big, bigg, Bigg } { \__deriv_set_scale:nnn {dv_#1} {##1} { eval } },
 		scale-eval-/ .choices:nn = { auto, none, big, Big, bigg, Bigg } { \__deriv_set_scale:nnn {dv_#1} {##1} { eval_slash } },
@@ -276,7 +296,7 @@
 		switch-* .bool_set:c = { l__deriv_dv_#1_switch_star_bool },
 		switch-/ .bool_set:c = { l__deriv_dv_#1_switch_slash_bool },
 		switch-sort .bool_set:c = { l__deriv_dv_#1_switch_sort_bool },
-		switch-compact .bool_set:c = { l__deriv_dv_#1_switch_compact_bool },
+		switch-! .bool_set:c = { l__deriv_dv_#1_switch_compact_bool },
 
 		
 		fun  .bool_set:c = { l__deriv_dv_#1_misc_fun_bool },
@@ -317,38 +337,23 @@
 	}
 }
 % variant, value, name
-\cs_new:Npn \__deriv_dv_set_style_var:nnn #1 #2 #3
+\cs_new:Npn \__deriv_set_style_var:nnn #1 #2 #3
 {
 	\str_case:nnF {#2}
 	{
-		{ single-up      } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_dv_build_single:NNNnn   } }
-		{ single-low     } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_i_build_single:NNNnn   } }
-		{ multiple-right } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_dv_build_multiple:NNNnn } }
-		{ multiple-left  } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_i_build_multiple:NNNnn } }
-		{ mixed          } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_i_build_mixed:NNNnn    } }
+		{ single-single  } { \tl_set:cn { l__deriv_#1_style_var#3_tl } { \__deriv_build_var_single_single:NNNnn } }
+		{ single-right   } { \tl_set:cn { l__deriv_#1_style_var#3_tl } { \__deriv_build_var_single_right:NNNnn } }
+		{ single-mixed   } { \tl_set:cn { l__deriv_#1_style_var#3_tl } { \__deriv_build_var_single_mixed:NNNnn } }
+		{ multiple-right } { \tl_set:cn { l__deriv_#1_style_var#3_tl } { \__deriv_build_var_multiple_right:NNNnn } }
+		{ multiple-left  } { \tl_set:cn { l__deriv_#1_style_var#3_tl } { \__deriv_build_var_multiple_left:NNNnn } }
+		{ multiple-mixed } { \tl_set:cn { l__deriv_#1_style_var#3_tl } { \__deriv_build_var_multiple_mixed:NNNnn } }
 	}
 	{ 
 		\msg_error:nnxx { deriv } { differential-option-not-defined } 
 		{#2} {'#2'}
 	}
 }
-% % varaint, value, name
-% variant, value, name
-\cs_new:Npn \__deriv_i_set_style_var:nnn #1 #2 #3
-{
-	\str_case:nnF {#2}
-	{
-		{ single-up      } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_dv_build_single:NNNnn   } }
-		{ single-low     } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_i_build_single:NNNnn   } }
-		{ multiple-right } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_dv_build_multiple:NNNnn } }
-		{ multiple-left  } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_i_build_multiple:NNNnn } }
-		{ mixed          } { \tl_set:cn { l__deriv_i_#1_style_var#3_tl } { \__deriv_i_build_mixed:NNNnn    } }
-	}
-	{ 
-		\msg_error:nnxx { deriv } { differential-option-not-defined } 
-		{#2} {'#2'}
-	}
-}
+
 % dv_variant, scale, name
 \cs_new:Npn \__deriv_set_scale:nnn #1 #2 #3
 {
@@ -386,8 +391,8 @@
 	\keys_define:nn { deriv/i/#1 }
 	{
 		style-inf .tl_set:c = { l__deriv_i_#1_style_inf_tl },
-		style-var   .code:n   = { \__deriv_i_set_style_var:nnn {#1} {##1} {}  },
-		style-var-* .code:n   = { \__deriv_i_set_style_var:nnn {#1} {##1} { _star } },
+		style-var   .code:n   = { \__deriv_set_style_var:nnn {i_#1} {##1} {}  },
+		style-var-* .code:n   = { \__deriv_set_style_var:nnn {i_#1} {##1} { _star } },
 		
 		scale-var   .choices:nn = { auto, none, big, Big, bigg, Bigg } { \__deriv_set_scale:nnn {i_#1} {##1} { var } },
 		scale-var-* .choices:nn = { auto, none, big, Big, bigg, Bigg } { \__deriv_set_scale:nnn {i_#1} {##1} { var_slash } },
@@ -495,7 +500,7 @@
 % variant
 \cs_new_protected:Npn \__deriv_dv_variables:n #1
 {
-	\__deriv_new:nnnn { tl    } {dv_#1} { style  } { inf, var, var_star, frac, frac_slash }
+	\__deriv_new:nnnn { tl    } {dv_#1} { style  } { inf, var, var_star, var_slash, var_compact, var_star_slash, var_star_compact, var_slash_compact, frac, frac_slash, frac_compact, frac_slash_compact }
 	\__deriv_new:nnnn { tl    } {dv_#1} { scale  } { eval, eval_slash, fun, var, frac, frac_slash }
 	\__deriv_new:nnnn { tl    } {dv_#1} { delims } { eval, eval_slash, fun, var, frac, frac_slash }
 	\__deriv_new:nnnn { tl    } {dv_#1} { sep    } { inf_ord, inf_fun, ord_fun, frac_fun, inf_var, var_ord, var_var, var_inf, ord_ord, ord_inf, ord_var, eval_sb, eval_sp }
@@ -554,20 +559,20 @@
 			{% slash = true
 				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
 				{% star and slash + compact
-					\msg_error:nnxx { deriv } { differential-options-incompatible } 
-					{'slash','star'~and~'compact'} {'slash','star'~and~'compact'}
-					\__deriv_dv_both:nnnnn  {dv_#2} {##3} {##6} {##7} {##8} 
+					% \msg_error:nnxx { deriv } { differential-options-incompatible } 
+					% {'slash','star'~and~'compact'} {'slash','star'~and~'compact'}
+					\__deriv_dv_star_slash_compact:nnnnn  {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 				{% slash only + compact
-					\msg_error:nnxx { deriv } { differential-options-incompatible } 
-					{'slash'~and~'compat'} {'slash'~and~'compact'}
-					\__deriv_dv_slash:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
+					% \msg_error:nnxx { deriv } { differential-options-incompatible } 
+					% {'slash'~and~'compat'} {'slash'~and~'compact'}
+					\__deriv_dv_slash_compact:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 			}
 			{% slash = false
 				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
 				{% star only + compact
-					\__deriv_dv_compact_star:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
+					\__deriv_dv_star_compact:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
 				}
 				{% no star no slash + compact
 					\__deriv_dv_compact:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
@@ -579,7 +584,7 @@
 			{% slash = true
 				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
 				{% star and slash 
-					\__deriv_dv_both:nnnnn  {dv_#2} {##3} {##6} {##7} {##8}  
+					\__deriv_dv_star_slash:nnnnn  {dv_#2} {##3} {##6} {##7} {##8}  
 				}
 				{% slash only
 					\__deriv_dv_slash:nnnnn {dv_#2} {##3} {##6} {##7} {##8} 
@@ -615,9 +620,10 @@
 
 %%%%%  derivative definition  %%%%%
 % variant, function, variable, sb-point, sp-point
-\cs_new_protected:Npn \__deriv_dv_both:nnnnn #1 #2 #3 #4 #5
+\cs_new_protected:Npn \__deriv_dv_star_slash:nnnnn #1 #2 #3 #4 #5
 {
-	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star}
+	star~slash
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star_slash}
 	\__deriv_evaluation_slash:nnnn {#1} {#4} {#5}
 	{
 		\__deriv_fraction_slash:nn {#1}
@@ -631,7 +637,7 @@
 }
 % variant, function, variable, sb-point, sp-point
 \cs_new_protected:Npn \__deriv_dv_star:nnnnn #1 #2 #3 #4 #5
-{
+{	% star
 	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star}
 	\__deriv_evaluation:nnnn {#1} {#4} {#5}
 	{
@@ -646,8 +652,8 @@
 }
 % variant, function, variable, sb-point, sp-point
 \cs_new_protected:Npn \__deriv_dv_slash:nnnnn #1 #2 #3 #4 #5
-{
-	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {}
+{ % slash
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_slash}
 	\__deriv_evaluation_slash:nnnn {#1} {#4} {#5}
 	{
 		\__deriv_fraction_slash:nn {#1}
@@ -660,7 +666,7 @@
 }
 % variant, function, variable, sb-point, sp-point
 \cs_new_protected:Npn \__deriv_dv_none:nnnnn #1 #2 #3 #4 #5
-{
+{	% none
 	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {}
 	\__deriv_evaluation:nnnn {#1} {#4} {#5}
 	{
@@ -674,24 +680,68 @@
 }
 % variant, function, variable, sb-point, sp-point
 \cs_new_protected:Npn \__deriv_dv_compact:nnnnn #1 #2 #3 #4 #5
-{
-	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {}
+{	% compact
+	% prepare denom_tl from variable
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_compact}
 	
 	\__deriv_evaluation:nnnn {#1} {#4} {#5}
 	{
-		\l__deriv_dv_denom_tl 
-		\__deriv_dv_no_numerator_fun:nn {#1} {#2}
+		\__deriv_fraction_compact:nn {#1}
+		{
+			\use:c { __deriv_#1_style_frac_compact:nn }
+			{ \l__deriv_dv_denom_tl }
+			{ \__deriv_dv_no_numerator_fun:nn {#1} {#2} }
+		}
 	}
 }
 % variant, function, variable, sb-point, sp-point
-\cs_new_protected:Npn \__deriv_dv_compact_star:nnnnn #1 #2 #3 #4 #5
-{
-	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star}
+\cs_new_protected:Npn \__deriv_dv_star_compact:nnnnn #1 #2 #3 #4 #5
+{  %star~compact
+	%
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star_compact}
 	
 	\__deriv_evaluation:nnnn {#1} {#4} {#5}
 	{
-		\l__deriv_dv_denom_tl 
-		\__deriv_dv_no_numerator_fun:nn {#1} {#2}
+		\__deriv_fraction_compact:nn {#1}
+		{
+			\use:c { __deriv_#1_style_frac_compact:nn }
+			{ \l__deriv_dv_denom_tl }
+			{  }
+		}
+		\__deriv_insert_fun:nnn {#1} {#2} { frac_fun }
+	}
+}
+% variant, function, variable, sb-point, sp-point
+\cs_new_protected:Npn \__deriv_dv_slash_compact:nnnnn #1 #2 #3 #4 #5
+{	%slash~compact
+	%
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_slash_compact}
+	
+	\__deriv_evaluation:nnnn {#1} {#4} {#5}
+	{
+		\__deriv_fraction_slash_compact:nn {#1}
+		{
+			\use:c { __deriv_#1_style_frac_slash_compact:nn }
+			{ \l__deriv_dv_denom_tl }
+			{ \__deriv_dv_no_numerator_fun:nn {#1} {#2} }
+		}
+	}
+}
+% variant, function, variable, sb-point, sp-point
+\cs_new_protected:Npn \__deriv_dv_star_slash_compact:nnnnn #1 #2 #3 #4 #5
+{	%star~slash~compact
+	%
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star_slash_compact}
+	
+	\__deriv_evaluation:nnnn {#1} {#4} {#5}
+	{
+		\__deriv_fraction_slash_compact:nn {#1}
+		{
+			\use:c { __deriv_#1_style_frac_slash_compact:nn }
+			{ \l__deriv_dv_denom_tl }
+			{  }
+		}
+		\__deriv_insert_fun:nnn {#1} {#2} { frac_fun }
 	}
 }
 % variant, function
@@ -720,6 +770,7 @@
 % dv
 \cs_new_protected:Npn \__deriv_dv_denominator:n #1
 { \tl_use:N \l__deriv_dv_denom_tl }
+
 % denom-tl, variant, variable, if star
 \cs_new_protected:Npn \__deriv_dv_preparation:Nnnn #1 #2 #3 #4
 {
@@ -730,7 +781,7 @@
 	\tl_use:c { l__deriv_#2_style_var#4_tl } \l__deriv_dv_var_seq \l__deriv_dv_order_seq #1 {#2} {#4}
 }
 % var_seq, order_seq, denom-tl, variant, if star
-\cs_new_protected:Npn \__deriv_dv_build_multiple:NNNnn #1 #2 #3 #4 #5
+\cs_new_protected:Npn \__deriv_build_var_multiple_right:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
 	\__deriv_adjust_ord_seq:NN \l__deriv_var_count_int #2
@@ -762,8 +813,39 @@
 		}
 	}
 }
+% var_seq, order_seq, denom-tl, variant, if star
+\cs_new_protected:Npn \__deriv_build_var_single_single:NNNnn #1 #2 #3 #4 #5
+{
+	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
+	\tl_set:Nf \l__deriv_tmpa_tl { \seq_use:Nn #1 { \__deriv_insert_mskip:nn {#4} { var_var } } }
+	
+	\__deriv_var_bool_seq:cNN { l__deriv_#4_misc_var_clist } \l__deriv_tmpa_seq \l__deriv_var_count_int
+	\int_set:Nn \l__deriv_tmpa_int { \seq_count:N #2 }
+	
+	\seq_map_indexed_inline:Nn #2
+	{
+		\tl_put_right:Nx \l__deriv_tmpb_tl
+		{
+			\exp_not:n {##2}
+			\int_compare:nNnF {##1} = { \l__deriv_tmpa_int }
+			{ \__deriv_insert_mskip:nn {#4} { ord_ord } }
+		}
+	}
+	\seq_pop_left:NN \l__deriv_tmpa_seq \l__deriv_tmpc_tl
+	\tl_put_right:Nx #3
+	{
+		\__deriv_insert_inf:n {#4}
+		\__deriv_insert_mskip:nn {#4} { inf_var }
+		\__deriv_insert_var:NVnn \l__deriv_tmpc_tl \l__deriv_tmpa_tl {#4} {#5}
+		\__deriv_show_order:NT \l__deriv_tmpb_tl
+		{ \__deriv_insert_ord:Nnn \l__deriv_tmpb_tl {#4} { var_ord } }
+	}
+	\str_if_eq:cNT { l__deriv_#4_misc_mixed_order_tl } 1
+	{ \tl_set_eq:cN { l__deriv_#4_misc_mixed_order_tl } \l__deriv_tmpb_tl }
+}
+
 % var_seq, order_seq, denom-tl, variant
-\cs_new_protected:Npn \__deriv_dv_build_single:NNNnn #1 #2 #3 #4 #5
+\cs_new_protected:Npn \__deriv_build_var_single_right:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
 	\__deriv_adjust_ord_seq:NN \l__deriv_var_count_int #2
@@ -881,7 +963,7 @@
 	\tl_use:c { l__deriv_#2_style_var#4_tl } \l__deriv_i_var_seq \l__deriv_i_order_seq #1 {#2} {#4}
 }
 % var-seq, order-seq,  print-tl, variant, if star
-\cs_new_protected:Npn \__deriv_i_build_single:NNNnn #1 #2 #3 #4 #5
+\cs_new_protected:Npn \__deriv_build_var_single_mixed:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
 	\__deriv_var_bool_seq:cNN { l__deriv_#4_misc_var_clist } \l__deriv_add_var_bool_seq \l__deriv_var_count_int
@@ -927,7 +1009,7 @@
 	}
 }
 % var-seq, order-seq,  print-tl, variant, if star
-\cs_new_protected:Npn \__deriv_i_build_multiple:NNNnn #1 #2 #3 #4 #5
+\cs_new_protected:Npn \__deriv_build_var_multiple_left:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
 	\__deriv_var_bool_seq:cNN { l__deriv_#4_misc_var_clist } \l__deriv_add_var_bool_seq \l__deriv_var_count_int
@@ -954,7 +1036,7 @@
 	}
 }
 % var-seq, order-seq,  print-tl, variant, if star
-\cs_new_protected:Npn \__deriv_i_build_mixed:NNNnn #1 #2 #3 #4 #5
+\cs_new_protected:Npn \__deriv_build_var_multiple_mixed:NNNnn #1 #2 #3 #4 #5
 {
 	\int_set:Nn \l__deriv_var_count_int { \seq_count:N #1 }
 	\__deriv_var_bool_seq:cNN { l__deriv_#4_misc_var_clist } \l__deriv_add_var_bool_seq \l__deriv_var_count_int
@@ -1037,6 +1119,20 @@
 {
 	\bool_if:cTF { l__deriv_#1_misc_frac_bool }
 	{ \__deriv_add_delims:nnn {#1} { frac_slash } {#2} }
+	{#2}
+}
+% dv, code-for-fraction
+\cs_new:Npn \__deriv_fraction_compact:nn #1 #2
+{
+	\bool_if:cTF { l__deriv_#1_misc_frac_bool }
+	{ \__deriv_add_delims:nnn {#1} { frac_compact } {#2} }
+	{#2}
+}
+% dv, code-for-fraction
+\cs_new:Npn \__deriv_fraction_slash_compact:nn #1 #2
+{
+	\bool_if:cTF { l__deriv_#1_misc_frac_bool }
+	{ \__deriv_add_delims:nnn {#1} { frac_slash_compact } {#2} }
 	{#2}
 }
 % dv, sub, sup, code-for-fraction
@@ -1545,23 +1641,23 @@
 	\DeclareDerivative{\odv}{\mathnormal{d}}
 	\DeclareDerivative{\mdv}{\mathnormal{D}}
 	\DeclareDifferential{\odif}{\mathnormal{d}}
-	\DeclareDifferential{\mdif}{\mathnormal{D}}[style-var=single-low, style-var-*=mixed]
+	\DeclareDifferential{\mdif}{\mathnormal{D}}[style-var=single-mixed, style-var-*=multiple-mixed]
 }
 {
 	\DeclareDerivative{\odv}{\mathrm{d}}
 	\DeclareDerivative{\mdv}{\mathrm{D}}
 	\DeclareDifferential{\odif}{\mathrm{d}}
-	\DeclareDifferential{\mdif}{\mathrm{D}}[style-var=single-low, style-var-*=mixed]
+	\DeclareDifferential{\mdif}{\mathrm{D}}[style-var=single-mixed, style-var-*=multiple-mixed]
 }
 
 \DeclareDerivative{\fdv}{\delta}
 \DeclareDerivative{\adv}{\Delta}
 \DeclareDerivative{\jdv}{\partial}[fun=true, var=1]
-\DeclareDerivative{\pdv}{\partial}[style-var=multiple-right, style-var-*=mixed, sep-inf-ord=1, delims-eval=(), delims-eval-/=()]
+\DeclareDerivative{\pdv}{\partial}[style-var=multiple-right, style-var-*=multiple-mixed, sep-inf-ord=1, delims-eval=(), delims-eval-/=()]
 
 \DeclareDifferential{\fdif}{\delta}
 \DeclareDifferential{\adif}{\Delta}
-\DeclareDifferential{\pdif}{\partial}[style-var=single-low, style-var-*=mixed]
+\DeclareDifferential{\pdif}{\partial}[style-var=single-mixed, style-var-*=multiple-mixed]
 
 \endinput
 

--- a/derivative.sty
+++ b/derivative.sty
@@ -143,7 +143,8 @@
 	style-inf     = d,
 	style-frac    = \frac,
 	style-frac-/  = \slashfrac,
-	style-var     = single,
+	style-var     = {single-up},
+	style-var-*   = {multiple-right},
 	scale-eval    = auto,
 	scale-eval-/  = auto,
 	scale-fun     = auto,
@@ -164,12 +165,15 @@
 	sep-var-ord   = 0,
 	sep-var-inf   = \mathop{}\!,
 	sep-ord-inf   = \mathop{}\!,
+	sep-ord-ord   = {,},
+	sep-ord-var   = 0,
 	sep-var-var   = {,},
 	sep-eval-sb   = 0,
 	sep-eval-sp   = 0,
 	switch-*      = false,
 	switch-/      = false,
 	switch-sort   = true,
+	switch-compact= false,
 	sort-method         = {sign, symbol, abs},
 	sort-numerical      = auto,
 	sort-abs-reverse    = false,
@@ -234,7 +238,8 @@
 	\keys_define:nn { deriv/dv/#1 }
 	{
 		style-inf    .tl_set:c  = { l__deriv_dv_#1_style_inf_tl },
-		style-var    .code:n    = { \__deriv_set_style_var:nn {#1} {##1} },
+		style-var    .code:n    = { \__deriv_set_style_var:nnn {#1} {##1} {} },
+		style-var-*  .code:n    = { \__deriv_set_style_var:nnn {#1} {##1} {_star} },
 		style-frac   .cs_set:cp = { __deriv_dv_#1_style_frac:nn } {##1},
 		style-frac-/ .cs_set:cp = { __deriv_dv_#1_style_frac_slash:nn } {##1},
 		
@@ -260,6 +265,8 @@
 		sep-var-ord  .code:n = { \__deriv_set_rubber_length:cn { l__deriv_dv_#1_sep_var_ord_tl  } {##1} },
 		sep-var-inf  .code:n = { \__deriv_set_rubber_length:cn { l__deriv_dv_#1_sep_var_inf_tl  } {##1} },
 		sep-ord-inf  .code:n = { \__deriv_set_rubber_length:cn { l__deriv_dv_#1_sep_ord_inf_tl  } {##1} },
+		sep-ord-ord  .code:n = { \__deriv_set_rubber_length:cn { l__deriv_dv_#1_sep_ord_ord_tl  } {##1} },
+		sep-ord-var  .code:n = { \__deriv_set_rubber_length:cn { l__deriv_dv_#1_sep_ord_var_tl  } {##1} },
 		sep-var-var  .code:n = { \__deriv_set_rubber_length:cn { l__deriv_dv_#1_sep_var_var_tl  } {##1} },
 		sep-eval-sb  .code:n = { \__deriv_set_rubber_length:cn { l__deriv_dv_#1_sep_eval_sb_tl  } {##1} },
 		sep-eval-sp  .code:n = { \__deriv_set_rubber_length:cn { l__deriv_dv_#1_sep_eval_sp_tl  } {##1} },
@@ -267,6 +274,8 @@
 		switch-* .bool_set:c = { l__deriv_dv_#1_switch_star_bool },
 		switch-/ .bool_set:c = { l__deriv_dv_#1_switch_slash_bool },
 		switch-sort .bool_set:c = { l__deriv_dv_#1_switch_sort_bool },
+		switch-compact .bool_set:c = { l__deriv_dv_#1_switch_compact_bool },
+
 		
 		fun  .bool_set:c = { l__deriv_dv_#1_misc_fun_bool },
 		frac .bool_set:c = { l__deriv_dv_#1_misc_frac_bool },
@@ -305,13 +314,20 @@
 		\int_compare:nNnT {##1} = { 3 } { \seq_map_break: }
 	}
 }
-% variant, value
-\cs_new:Npn \__deriv_set_style_var:nn #1 #2
+% variant, value, name
+\cs_new:Npn \__deriv_set_style_var:nnn #1 #2 #3
 {
-	\str_case:nn {#2}
+	\str_case:nnF {#2}
 	{
-		{ single   } { \tl_set:cn { l__deriv_dv_#1_style_var_tl } { \__deriv_dv_build_single:NNNn   } }
-		{ multiple } { \tl_set:cn { l__deriv_dv_#1_style_var_tl } { \__deriv_dv_build_multiple:NNNn } }
+		{ single-up      } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_dv_build_single:NNNnn   } }
+		{ single-low     } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_i_build_single:NNNnn   } }
+		{ multiple-right } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_dv_build_multiple:NNNnn } }
+		{ multiple-left  } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_i_build_multiple:NNNnn } }
+		{ mixed          } { \tl_set:cn { l__deriv_dv_#1_style_var#3_tl } { \__deriv_i_build_mixed:NNNnn    } }
+	}
+	{ 
+		\msg_error:nnxx { deriv } { differential-option-not-defined } 
+		{#2} {'#2'}
 	}
 }
 % varaint, value, name
@@ -468,11 +484,11 @@
 % variant
 \cs_new_protected:Npn \__deriv_dv_variables:n #1
 {
-	\__deriv_new:nnnn { tl    } {dv_#1} { style  } { inf, var, frac, frac_slash }
+	\__deriv_new:nnnn { tl    } {dv_#1} { style  } { inf, var, var_star, frac, frac_slash }
 	\__deriv_new:nnnn { tl    } {dv_#1} { scale  } { eval, eval_slash, fun, var, frac, frac_slash }
 	\__deriv_new:nnnn { tl    } {dv_#1} { delims } { eval, eval_slash, fun, var, frac, frac_slash }
-	\__deriv_new:nnnn { tl    } {dv_#1} { sep    } { inf_ord, inf_fun, ord_fun, frac_fun, inf_var, var_ord, var_inf, ord_inf, eval_sb, eval_sp }
-	\__deriv_new:nnnn { bool  } {dv_#1} { switch } { star, slash, sort }
+	\__deriv_new:nnnn { tl    } {dv_#1} { sep    } { inf_ord, inf_fun, ord_fun, frac_fun, inf_var, var_ord, var_var, var_inf, ord_ord, ord_inf, ord_var, eval_sb, eval_sp }
+	\__deriv_new:nnnn { bool  } {dv_#1} { switch } { star, slash, compact, sort }
 	\__deriv_new:nnnn { seq   } {dv_#1} { sort   } { method }
 	\__deriv_new:nnnn { tl    } {dv_#1} { sort   } { numerical }
 	\__deriv_new:nnnn { bool  } {dv_#1} { sort   } { abs_reverse, sign_reverse, symbol_reverse, number_reverse, lexical_reverse }
@@ -521,16 +537,52 @@
 	\group_begin:
 		\deriv_local_keys:nnn {##2} { dv } {#2}
 		
-		\exp_args:Nnc \bool_xor:nnTF {##4} { l__deriv_dv_#2_switch_slash_bool }
-		{
-			\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
-			{ \__deriv_dv_both:nnnnn  {dv_#2} {##3} {##5} {##6} {##7} }
-			{ \__deriv_dv_slash:nnnnn {dv_#2} {##3} {##5} {##6} {##7} }
+		\exp_args:Nc \bool_if:nTF {l__deriv_dv_#2_switch_compact_bool}
+		{%compact = true
+			\exp_args:Nnc \bool_xor:nnTF {##4} { l__deriv_dv_#2_switch_slash_bool }
+			{% slash = true
+				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
+				{% star and slash + compact
+					\msg_error:nnxx { deriv } { differential-options-incompatible } 
+					{'slash','star'~and~'compact'} {'slash','star'~and~'compact'}
+					\__deriv_dv_both:nnnnn  {dv_#2} {##3} {##5} {##6} {##7} 
+				}
+				{% slash only + compact
+					\msg_error:nnxx { deriv } { differential-options-incompatible } 
+					{'slash'~and~'compat'} {'slash'~and~'compact'}
+					\__deriv_dv_slash:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+				}
+			}
+			{% slash = false
+				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
+				{% star only + compact
+					\__deriv_dv_compact_star:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+				}
+				{% no star no slash + compact
+					\__deriv_dv_compact:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+				}
+			}
 		}
-		{
-			\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
-			{ \__deriv_dv_star:nnnnn {dv_#2} {##3} {##5} {##6} {##7} }
-			{ \__deriv_dv_none:nnnnn {dv_#2} {##3} {##5} {##6} {##7} }
+		{% compact = false
+			\exp_args:Nnc \bool_xor:nnTF {##4} { l__deriv_dv_#2_switch_slash_bool }
+			{% slash = true
+				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
+				{% star and slash 
+					\__deriv_dv_both:nnnnn  {dv_#2} {##3} {##5} {##6} {##7} 
+				}
+				{% slash only
+					\__deriv_dv_slash:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+				}
+			}
+			{% slash = false
+				\exp_args:Nnc \bool_xor:nnTF {##1} { l__deriv_dv_#2_switch_star_bool }
+				{% star only  
+					\__deriv_dv_star:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+				}
+				{% no star no slash
+					\__deriv_dv_none:nnnnn {dv_#2} {##3} {##5} {##6} {##7} 
+				}
+			}
 		}
 	\group_end:
 	}
@@ -609,6 +661,28 @@
 		}
 	}
 }
+% variant, function, variable, sb-point, sp-point
+\cs_new_protected:Npn \__deriv_dv_compact:nnnnn #1 #2 #3 #4 #5
+{
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {}
+	
+	\__deriv_evaluation:nnnn {#1} {#4} {#5}
+	{
+		\l__deriv_dv_denom_tl 
+		\__deriv_dv_no_numerator_fun:nn {#1} {#2}
+	}
+}
+% variant, function, variable, sb-point, sp-point
+\cs_new_protected:Npn \__deriv_dv_compact_star:nnnnn #1 #2 #3 #4 #5
+{
+	\__deriv_dv_preparation:Nnnn \l__deriv_dv_denom_tl {#1} {#3} {_star}
+	
+	\__deriv_evaluation:nnnn {#1} {#4} {#5}
+	{
+		\l__deriv_dv_denom_tl 
+		\__deriv_dv_no_numerator_fun:nn {#1} {#2}
+	}
+}
 % variant, function
 \cs_new_protected:Npn \__deriv_dv_numerator_fun:nn #1 #2
 {
@@ -619,6 +693,11 @@
 		\__deriv_insert_fun:nnn {#1} {#2} { ord_fun }
 	}
 	{ \__deriv_insert_fun:nnn {#1} {#2} { inf_fun } }
+}
+% variant, function
+\cs_new_protected:Npn \__deriv_dv_no_numerator_fun:nn #1 #2
+{
+	\__deriv_insert_fun:nnn {#1} {#2} { ord_fun }
 }
 % variant
 \cs_new_protected:Npn \__deriv_dv_numerator_nofun:n #1
@@ -904,14 +983,7 @@
 		{#2}
 	}
 }
-% if delim, variable, variant
-\cs_new:Npn \__deriv_insert_var:Nnn #1 #2 #3
-{
-	\bool_if:NTF #1
-	{ \__deriv_add_delims:nnn {#3} { var } {#2} }
-	{ \__deriv_handle_double_sp:n {#2} }
-}
-% if delim, variable, variant, star
+% if delim, variable, variant, if star
 \cs_new:Npn \__deriv_insert_var:Nnnn #1 #2 #3 #4
 {
 	\bool_if:NTF #1
@@ -1405,7 +1477,7 @@
 \cs_generate_variant:Nn \__deriv_scale_big_auxi:nNn { nc }
 
 \cs_generate_variant:Nn \__deriv_insert_ord:Nnn { c }
-\cs_generate_variant:Nn \__deriv_insert_var:Nnn { NV }
+\cs_generate_variant:Nn \__deriv_insert_var:Nnnn { NV }
 
 \cs_generate_variant:Nn \__deriv_mixed_order:NNn { c }
 \cs_generate_variant:Nn \__deriv_sort_method:Nn { c }
@@ -1439,12 +1511,16 @@
 { The~key~'#1'~only~accepts~the~values~'true'~and~'false'. }
 
 \msg_new:nnnn { deriv } { derivative-option-not-defined }
-{ Derivative option~'#1'~not~yet~defined! }
+{ Derivative~option~'#1'~not~yet~defined! }
 { You~have~used~#2~with~a~derivative~option~that~was~never~defined. }
 
 \msg_new:nnnn { deriv } { differential-option-not-defined }
-{ Differential option~'#1'~not~yet~defined! }
+{ Differential~option~'#1'~not~yet~defined! }
 { You~have~used~#2~with~a~differential~option~that~was~never~defined. }
+
+\msg_new:nnnn { deriv } { differential-options-incompatible }
+{ Differential~options~#1~are~not~compatible! }
+{ You~have~used~#2~options~that~are~incompatible. }
 
 %%%%%  Declaring derivatives  %%%%%
 
@@ -1470,7 +1546,7 @@
 \DeclareDerivative{\fdv}{\delta}
 \DeclareDerivative{\adv}{\Delta}
 \DeclareDerivative{\jdv}{\partial}[fun=true, var=1]
-\DeclareDerivative{\pdv}{\partial}[style-var=multiple, sep-inf-ord=1, delims-eval=(), delims-eval-/=()]
+\DeclareDerivative{\pdv}{\partial}[style-var=multiple-right, style-var-*=mixed, sep-inf-ord=1, delims-eval=(), delims-eval-/=()]
 
 \DeclareDifferential{\fdif}{\delta}
 \DeclareDifferential{\adif}{\Delta}


### PR DESCRIPTION
I tried to contribute (as said before) by bringing 3 things in the pull (merge) request:
1. fix dv_build_single function
2. add compact option to \pdv and friends
3. use style-var instead of style-notation for \pdif and friends 

# 1. fix dv_build_single function
I noticed a buggus in the display of the option `style-var=single` when combined with `order={...}`.
As an example, let's take the following command `\pdv[style-var=single, order={n,1,2}]{f}{x,y,z,t}`.
As you can see on the following image, order are not displayed correctly. 
[![bug][1]][1]

  [1]: https://i.stack.imgur.com/Eitd4.png
For my understanding it was due to your function `dv_build_single` that was treating the variable sequence as a block, so adding orders were not treated correctly.
Therefore, I suggest a correction of this function which leads to the following result for the same previous command.
[![fix][2]][2]

  [2]: https://i.stack.imgur.com/zQPMR.png

# 2. add compact option to \pdv and friends
This my proposal to solve the issue #1 about compact style. 
I add a boolean switch to activate this option. 
When it is activated, I reuse your functions `\..._build_single`, `\..._build_multiple` or `\...build_mixed` from `\pdif` and `\pdv` + friends  to get a compact differential of variables, then I add the function without `frac` command. 
I had to add some `sep` variables to both `\pdv` and `\pdif`to make it compatible with `\...build_single...` from each.
I tried to reuse as much as I could your existing code, this allowed me to have a star + compact style possible (inspired by `\pdif*` behavior).
I add some error message when `compact` and `slash` options are active since there are mutually exclusive (slash wins over compact).
However, I had to rename `single` and `multiple` styles to be able to use `single` from `\pdv` (which became `single-up`) and `single` from `\pdif` (now `single-low`) or `multiple` from `\pdv` (now `multiple-right`) and `multiple` from `\pdif` (now `multiple-left`).
I am not really satisfied by these names but I did not find better for now. 
Here is a list of commands that are now possible.

    compact style single-up $\pdv[style-var=single-up, switch-compact=true, order={n,1,2}]{f}{x,y,z,t}_{a}^{b} $
    
    compact style single-low $\pdv[style-var=single-low, switch-compact=true, order={n,1,2}]{f}{x,y,z,t}_{a}^{b} $
    
    compact style multiple-left $\pdv[style-var=multiple-left, switch-compact=true, order={n,1,2}]{f}{x,y,z,t}_{a}^{b} $
    
    compact style multiple-right $\pdv[style-var=multiple-right, switch-compact=true, order={n,1,2}]{f}{x,y,z,t}_{a}^{b} $
    
    compact style mixed $\pdv[style-var=mixed, order={n,1,2}]{f}!{x,y,z,t}_{a}^{b} $

Giving you:
[![compact][3]][3]

  [3]: https://i.stack.imgur.com/XFXTj.png

# 3. use style-var instead of style-notation for \pdif and friends 
I also unified the options `style-var` from `\pdv`  and `style-notation` from `\pdif` since they are tweaking the same things.
So, to me they should have the same name for clarity.
Plus, the compact style also allows these 2 options to use the same function `\...build...`.

If you think about accepting these modifications (or a part of them), please let me know, so I could add/update the documentation (or help you in another way if needed).